### PR TITLE
fix:

### DIFF
--- a/plugins/made-tokens/json/made-unify-tokens.json
+++ b/plugins/made-tokens/json/made-unify-tokens.json
@@ -5352,7 +5352,7 @@
         }
       },
       "textarea": {
-        "default": {
+        "medium": {
           "padding-x": {
             "$componentLevelToken": "true",
             "$type": "spacing",
@@ -8957,7 +8957,7 @@
         }
       },
       "textarea": {
-        "default": {
+        "medium": {
           "padding-x": {
             "$componentLevelToken": "true",
             "$type": "spacing",
@@ -12480,7 +12480,7 @@
         }
       },
       "textarea": {
-        "default": {
+        "medium": {
           "padding-x": {
             "$componentLevelToken": "true",
             "$type": "spacing",
@@ -17404,8 +17404,6 @@
         "component.table.cell.data.font-weight": "8ce8d531e856cab0d7cc24342a33445b12aeee9e",
         "component.table.cell.data.line-height": "2aaf5b16746f87ffb874c75eb529a9c71983c112",
         "component.table.border-radius": "8460ece4ca59b5d0783209fdb3ea18042861ffb8",
-        "component.textarea.default.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
-        "component.textarea.default.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f",
         "component.textarea.large.padding-x": "7eb31ea20382c6d4ca72cc1579c1f4df7e2fdb66",
         "component.textarea.large.padding-y": "12137718e5dd8eb236801cf3a764f0e6fe326eca",
         "component.drawer-picker.padding-x": "cee89d16db31c7beeadf6a5c81c3b183daa4294f",
@@ -17488,7 +17486,9 @@
         "font-weight.h6": "9b4a35b1472d74c70e35fb96c7526470d784348a",
         "font-weight.eyebrow": "34160f671e75bf9f6dfa4bafdadf40bd1b63c4cd",
         "font-weight.link": "875061cb2262c6cf299a9985d2c63a7a013761a7",
-        "component.link.hover.text-mode-dark": "09841d3dfac56b4ea6935ae049f5677cf01a6899"
+        "component.link.hover.text-mode-dark": "09841d3dfac56b4ea6935ae049f5677cf01a6899",
+        "component.textarea.medium.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
+        "component.textarea.medium.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f"
       },
       "$figmaCollectionId": "VariableCollectionId:1:5",
       "$figmaModeId": "1:4",
@@ -18104,8 +18104,6 @@
         "component.table.cell.data.font-weight": "8ce8d531e856cab0d7cc24342a33445b12aeee9e",
         "component.table.cell.data.line-height": "2aaf5b16746f87ffb874c75eb529a9c71983c112",
         "component.table.border-radius": "8460ece4ca59b5d0783209fdb3ea18042861ffb8",
-        "component.textarea.default.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
-        "component.textarea.default.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f",
         "component.textarea.large.padding-x": "7eb31ea20382c6d4ca72cc1579c1f4df7e2fdb66",
         "component.textarea.large.padding-y": "12137718e5dd8eb236801cf3a764f0e6fe326eca",
         "component.drawer-picker.padding-x": "cee89d16db31c7beeadf6a5c81c3b183daa4294f",
@@ -18189,7 +18187,9 @@
         "font-weight.eyebrow": "34160f671e75bf9f6dfa4bafdadf40bd1b63c4cd",
         "font-weight.link": "875061cb2262c6cf299a9985d2c63a7a013761a7",
         "color.border.strongest-mode-light": "3ab4ff526239620a34d8636e00b5f552de3715ae",
-        "color.border.strongest-mode-dark": "30d5ef2b02a161c223e7d9f96f85acab7d406fd4"
+        "color.border.strongest-mode-dark": "30d5ef2b02a161c223e7d9f96f85acab7d406fd4",
+        "component.textarea.medium.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
+        "component.textarea.medium.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f"
       },
       "$figmaCollectionId": "VariableCollectionId:1:5",
       "$figmaModeId": "1:3",
@@ -18773,8 +18773,6 @@
         "component.table.cell.data.font-weight": "8ce8d531e856cab0d7cc24342a33445b12aeee9e",
         "component.table.cell.data.line-height": "2aaf5b16746f87ffb874c75eb529a9c71983c112",
         "component.table.border-radius": "8460ece4ca59b5d0783209fdb3ea18042861ffb8",
-        "component.textarea.default.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
-        "component.textarea.default.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f",
         "component.textarea.large.padding-x": "7eb31ea20382c6d4ca72cc1579c1f4df7e2fdb66",
         "component.textarea.large.padding-y": "12137718e5dd8eb236801cf3a764f0e6fe326eca",
         "component.drawer-picker.padding-x": "cee89d16db31c7beeadf6a5c81c3b183daa4294f",
@@ -18857,7 +18855,9 @@
         "font-weight.h6": "9b4a35b1472d74c70e35fb96c7526470d784348a",
         "font-weight.eyebrow": "34160f671e75bf9f6dfa4bafdadf40bd1b63c4cd",
         "font-weight.link": "875061cb2262c6cf299a9985d2c63a7a013761a7",
-        "component.link.hover.text-color-mode-dark": "54cab3abef3c6a61cb59396026d88bc81740dfb4"
+        "component.link.hover.text-color-mode-dark": "54cab3abef3c6a61cb59396026d88bc81740dfb4",
+        "component.textarea.medium.padding-x": "42bb30661b3def3dbda34543a731cd88f3ce073f",
+        "component.textarea.medium.padding-y": "865cb72b70ea6864b5e05747a2420af42e8fd50f"
       },
       "$figmaCollectionId": "VariableCollectionId:1:5",
       "$figmaModeId": "1:5",

--- a/plugins/made-tokens/json/made-unify-tokens.json
+++ b/plugins/made-tokens/json/made-unify-tokens.json
@@ -6161,7 +6161,7 @@
             "studio.tokens": {
               "modify": {
                 "type": "alpha",
-                "value": "0.7",
+                "value": "0.4",
                 "space": "lch"
               }
             }
@@ -6174,7 +6174,7 @@
             "studio.tokens": {
               "modify": {
                 "type": "alpha",
-                "value": "0.7",
+                "value": "0.4",
                 "space": "lch"
               }
             }
@@ -7477,7 +7477,7 @@
           "padding-right": {
             "$componentLevelToken": "true",
             "$type": "spacing",
-            "$value": "{size-space.12-x}"
+            "$value": "{size-space.6-x}"
           }
         },
         "border-radius": {


### PR DESCRIPTION
Missed a change in the last update, correcting the size tokens for the Text Area component-level tokens to change the term "default" to "medium". This applies to the following tokens in each theme:

component.textarea.medium.padding-x
component.textarea.medium.padding-y