### PR TITLE
The design tokens build (npm run build) is failing on token reference…

### DIFF
--- a/plugins/made-tokens/json/made-unify-tokens.json
+++ b/plugins/made-tokens/json/made-unify-tokens.json
@@ -10594,7 +10594,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}",
+          "$value": "{color.gray.950}",
           "$description": "This token is for the color of a shadow. \"Subtle\" is the lowest level of shadow opacity. "
         },
         "subtle-mode-dark": {
@@ -10608,7 +10608,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}"
+          "$value": "{color.gray.950}"
         },
         "medium-mode-light": {
           "$extensions": {
@@ -10621,7 +10621,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}"
+          "$value": "{color.gray.950}"
         },
         "medium-mode-dark": {
           "$extensions": {
@@ -10634,7 +10634,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}"
+          "$value": "{color.gray.950}"
         },
         "strong-mode-light": {
           "$extensions": {
@@ -10647,7 +10647,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}"
+          "$value": "{color.gray.950}"
         },
         "strong-mode-dark": {
           "$extensions": {
@@ -10660,7 +10660,7 @@
             }
           },
           "$type": "color",
-          "$value": "{color.gray.1800}"
+          "$value": "{color.gray.950}"
         }
       }
     },
@@ -11671,7 +11671,7 @@
           "box-shadow": {
             "$componentLevelToken": "true",
             "$type": "boxShadow",
-            "$value": "{box-shadow.default}"
+            "$value": "{box-shadow.small}"
           },
           "width": {
             "$componentLevelToken": "true",


### PR DESCRIPTION
… issues in

made-unify-tokens.json.

- Theme / mode being built when it failed: unify / light
 
Failing references (20 total):
1) {color.gray.1800} — referenced 19 times, but the Unify gray primitive palette
   only defines shades 50–950 (no 1800). Only the Mastercard palette defines
   gray.1800 (#141413). Affected tokens include:
     - color.shadow.subtle/medium/strong-mode-light and -mode-dark
     - color.box-shadow.subtle/medium/strong - box-shadow.small/medium/large/x-large - component.alert.toast.box-shadow, component.modal.box-shadow, component.card.box-shadow, component.listbox.box-shadow, component.date-picker.box-shadow, component.tooltip.box-shadow
 
2) {box-shadow.default} — referenced by component.range.thumb.box-shadow, but
   box-shadow.default is not defined anywhere in the JSON.
 
FIX: The following tokens in the Unify theme were referencing color.gray.1800 and I have now changed this to color.gray.950:

color.shadow.subtle/medium/strong-mode-light and -mode-dark

This cascades to the rest of the tokens listed above. 

For token: component.range.thumb.box-shadow, I changed the reference value to box-shadow.subtle

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}